### PR TITLE
Remove local file saving and rewrite processing to remove blocking calls

### DIFF
--- a/custom_components/openai_whisper_cloud/stt.py
+++ b/custom_components/openai_whisper_cloud/stt.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 
 from collections.abc import AsyncIterable
 import logging
-import os
-import tempfile
 import wave
 import io
 import asyncio


### PR DESCRIPTION
Home Assistant gives the following warning about blocking calls (plus a few afterwards). This PR removes blocking calls and removes the need to save a file locally.

Detected blocking call to open inside the event loop by custom integration 'openai_whisper_cloud' at custom_components/openai_whisper_cloud/stt.py, line 124: audio_file = open(temp_file_path, "rb") (offender: /config/custom_components/openai_whisper_cloud/stt.py, line 124: audio_file = open(temp_file_path, "rb")), please create a bug report at https://github.com/fabio-garavini/openai_whisper_cloud/issues Traceback (most recent call last): File "<frozen runpy>", line 198, in _run_module_as_main File "<frozen runpy>", line 88, in _run_code File "/usr/src/homeassistant/homeassistant/__main__.py", line 223, in <module> sys.exit(main()) File "/usr/src/homeassistant/homeassistant/__main__.py", line 209, in main exit_code = runner.run(runtime_conf) File "/usr/src/homeassistant/homeassistant/runner.py", line 190, in run return loop.run_until_complete(setup_and_run_hass(runtime_config)) File "/usr/local/lib/python3.12/asyncio/base_events.py", line 672, in run_until_complete self.run_forever() File "/usr/local/lib/python3.12/asyncio/base_events.py", line 639, in run_forever self._run_once() File "/usr/local/lib/python3.12/asyncio/base_events.py", line 1988, in _run_once handle._run() File "/usr/local/lib/python3.12/asyncio/events.py", line 88, in _run self._context.run(self._callback, *self._args) File "/usr/src/homeassistant/homeassistant/components/esphome/voice_assistant.py", line 219, in run_pipeline await async_pipeline_from_audio_stream( File "/usr/src/homeassistant/homeassistant/components/assist_pipeline/__init__.py", line 124, in async_pipeline_from_audio_stream await pipeline_input.execute() File "/usr/src/homeassistant/homeassistant/components/assist_pipeline/pipeline.py", line 1402, in execute intent_input = await self.run.speech_to_text( File "/usr/src/homeassistant/homeassistant/components/assist_pipeline/pipeline.py", line 882, in speech_to_text result = await self.stt_provider.async_process_audio_stream( File "/config/custom_components/openai_whisper_cloud/stt.py", line 124, in async_process_audio_stream audio_file = open(temp_file_path, "rb")