### PR TITLE
Adding support for noise reduction

### DIFF
--- a/custom_components/openai_whisper_cloud/__init__.py
+++ b/custom_components/openai_whisper_cloud/__init__.py
@@ -86,16 +86,14 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry):
             config_entry, data=new_data, options=new_options, minor_version=1, version=1
         )
 
-    if config_entry.version == 1 and config_entry.minor_version == 1:
+    if config_entry.version == 1 and ( config_entry.minor_version == 1 or config_entry.minor_version == 2 ) :
         new_options = {
-            CONF_MODEL: config_entry.data.get(CONF_MODEL, 0),
-            CONF_TEMPERATURE: config_entry.data.get(CONF_TEMPERATURE, DEFAULT_TEMPERATURE),
-            CONF_PROMPT: config_entry.data.get(CONF_PROMPT, DEFAULT_PROMPT),
+            **config_entry.data,
             CONF_REDUCE_NOISE: False,
         }
 
         hass.config_entries.async_update_entry(
-            config_entry, options=new_options, minor_version=2, version=1
+            config_entry, options=new_options, minor_version=3, version=1
         )
 
     _LOGGER.info(f"Migration of {config_entry.entry_id} successful")

--- a/custom_components/openai_whisper_cloud/__init__.py
+++ b/custom_components/openai_whisper_cloud/__init__.py
@@ -10,7 +10,15 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 
-from .const import _LOGGER, CONF_PROMPT, CONF_TEMPERATURE
+from .const import (
+    _LOGGER,
+    CONF_PROMPT,
+    CONF_TEMPERATURE,
+    CONF_REDUCE_NOISE,
+    DEFAULT_PROMPT,
+    DEFAULT_TEMPERATURE,
+    DEFAULT_REDUCE_NOISE
+)
 
 PLATFORMS = [Platform.STT]
 
@@ -76,6 +84,18 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry):
 
         hass.config_entries.async_update_entry(
             config_entry, data=new_data, options=new_options, minor_version=1, version=1
+        )
+
+    if config_entry.version == 1 and config_entry.minor_version == 1:
+        new_options = {
+            CONF_MODEL: config_entry.data.get(CONF_MODEL, 0),
+            CONF_TEMPERATURE: config_entry.data.get(CONF_TEMPERATURE, DEFAULT_TEMPERATURE),
+            CONF_PROMPT: config_entry.data.get(CONF_PROMPT, DEFAULT_PROMPT),
+            CONF_REDUCE_NOISE: False,
+        }
+
+        hass.config_entries.async_update_entry(
+            config_entry, options=new_options, minor_version=2, version=1
         )
 
     _LOGGER.info(f"Migration of {config_entry.entry_id} successful")

--- a/custom_components/openai_whisper_cloud/config_flow.py
+++ b/custom_components/openai_whisper_cloud/config_flow.py
@@ -36,8 +36,10 @@ from .const import (
     CONF_CUSTOM_PROVIDER,
     CONF_PROMPT,
     CONF_TEMPERATURE,
+    CONF_REDUCE_NOISE,
     DEFAULT_PROMPT,
     DEFAULT_TEMPERATURE,
+    DEFAULT_REDUCE_NOISE,
     DOMAIN,
 )
 from .whisper_provider import WhisperModel, WhisperProvider, whisper_providers
@@ -69,6 +71,8 @@ async def validate_input(data: dict, provider: WhisperProvider):
         data[CONF_TEMPERATURE] = DEFAULT_TEMPERATURE
     if data.get(CONF_PROMPT) is None:
         data[CONF_PROMPT] = DEFAULT_PROMPT
+    if data.get(CONF_REDUCE_NOISE) is None:
+        data[CONF_REDUCE_NOISE] = DEFAULT_REDUCE_NOISE
 
     response = await asyncio.to_thread(
         requests.get,
@@ -120,7 +124,8 @@ class OptionsFlowHandler(OptionsFlowWithConfigEntry):
                         ].models
                     ].index(user_input[CONF_MODEL]) if not self.config_entry.data.get(CONF_CUSTOM_PROVIDER) else user_input[CONF_MODEL],
                     CONF_TEMPERATURE: user_input[CONF_TEMPERATURE],
-                    CONF_PROMPT: user_input.get(CONF_PROMPT, ""),
+                    CONF_PROMPT: user_input.get(CONF_PROMPT, DEFAULT_PROMPT),
+                    CONF_REDUCE_NOISE: user_input.get(CONF_REDUCE_NOISE, DEFAULT_REDUCE_NOISE),
                 },
             )
 
@@ -141,6 +146,7 @@ class OptionsFlowHandler(OptionsFlowWithConfigEntry):
                             vol.Coerce(float), vol.Range(min=0, max=1)
                         ),
                         vol.Optional(CONF_PROMPT): cv.string,
+                        vol.Optional(CONF_REDUCE_NOISE): cv.boolean,
                     }
                 ),
                 suggested_values={
@@ -148,7 +154,8 @@ class OptionsFlowHandler(OptionsFlowWithConfigEntry):
                     .models[self.config_entry.options[CONF_MODEL]]
                     .name if not self.config_entry.data.get(CONF_CUSTOM_PROVIDER) else self.config_entry.options[CONF_MODEL],
                     CONF_TEMPERATURE: self.config_entry.options[CONF_TEMPERATURE],
-                    CONF_PROMPT: self.config_entry.options.get(CONF_PROMPT, ""),
+                    CONF_PROMPT: self.config_entry.options.get(CONF_PROMPT, DEFAULT_PROMPT),
+                    CONF_REDUCE_NOISE: self.config_entry.options.get(CONF_REDUCE_NOISE, DEFAULT_REDUCE_NOISE),
                 },
             ),
             errors=errors,
@@ -259,6 +266,7 @@ class ConfigFlow(ConfigFlow, domain=DOMAIN):
                             CONF_TEMPERATURE, default=DEFAULT_TEMPERATURE
                         ): vol.All(vol.Coerce(float), vol.Range(min=0, max=1)),
                         vol.Optional(CONF_PROMPT): cv.string,
+                        vol.Optional(CONF_REDUCE_NOISE): cv.boolean,
                     }
                 ),
                 errors=errors,
@@ -282,6 +290,7 @@ class ConfigFlow(ConfigFlow, domain=DOMAIN):
                         CONF_TEMPERATURE, default=DEFAULT_TEMPERATURE
                     ): vol.All(vol.Coerce(float), vol.Range(min=0, max=1)),
                     vol.Optional(CONF_PROMPT): cv.string,
+                    vol.Optional(CONF_REDUCE_NOISE): cv.boolean,
                 }
             ),
             errors=errors,
@@ -313,7 +322,8 @@ class ConfigFlow(ConfigFlow, domain=DOMAIN):
                     options={
                         CONF_MODEL: user_input[CONF_MODEL],
                         CONF_TEMPERATURE: user_input[CONF_TEMPERATURE],
-                        CONF_PROMPT: user_input.get(CONF_PROMPT, ""),
+                        CONF_PROMPT: user_input.get(CONF_PROMPT, DEFAULT_PROMPT),
+                        CONF_REDUCE_NOISE: user_input.get(CONF_REDUCE_NOISE, DEFAULT_REDUCE_NOISE),
                     },
                 )
 
@@ -336,6 +346,7 @@ class ConfigFlow(ConfigFlow, domain=DOMAIN):
                                 CONF_TEMPERATURE, default=DEFAULT_TEMPERATURE
                             ): vol.All(vol.Coerce(float), vol.Range(min=0, max=1)),
                             vol.Optional(CONF_PROMPT): cv.string,
+                            vol.Optional(CONF_REDUCE_NOISE): cv.boolean,
                         }
                     ),
                     suggested_values={
@@ -344,6 +355,7 @@ class ConfigFlow(ConfigFlow, domain=DOMAIN):
                         CONF_MODEL: entry.options.get(CONF_MODEL),
                         CONF_TEMPERATURE: entry.options.get(CONF_TEMPERATURE),
                         CONF_PROMPT: entry.options.get(CONF_PROMPT),
+                        CONF_REDUCE_NOISE: entry.options.get(CONF_REDUCE_NOISE),
                     },
                 ),
                 errors=errors,
@@ -376,7 +388,8 @@ class ConfigFlow(ConfigFlow, domain=DOMAIN):
                             user_input[CONF_MODEL]
                         ),
                         CONF_TEMPERATURE: user_input[CONF_TEMPERATURE],
-                        CONF_PROMPT: user_input.get(CONF_PROMPT, ""),
+                        CONF_PROMPT: user_input.get(CONF_PROMPT, DEFAULT_PROMPT),
+                        CONF_REDUCE_NOISE: user_input.get(CONF_REDUCE_NOISE, DEFAULT_REDUCE_NOISE),
                     },
                 )
                 await self.hass.config_entries.async_reload(self.context["entry_id"])
@@ -411,6 +424,7 @@ class ConfigFlow(ConfigFlow, domain=DOMAIN):
                             CONF_TEMPERATURE, default=DEFAULT_TEMPERATURE
                         ): vol.All(vol.Coerce(float), vol.Range(min=0, max=1)),
                         vol.Optional(CONF_PROMPT): cv.string,
+                        vol.Optional(CONF_REDUCE_NOISE): cv.boolean,
                     }
                 ),
                 suggested_values={
@@ -418,6 +432,7 @@ class ConfigFlow(ConfigFlow, domain=DOMAIN):
                     CONF_MODEL: whisper.name,
                     CONF_TEMPERATURE: entry.options.get(CONF_TEMPERATURE),
                     CONF_PROMPT: entry.options.get(CONF_PROMPT),
+                    CONF_REDUCE_NOISE: entry.options.get(CONF_REDUCE_NOISE),
                 },
             ),
             errors=errors,

--- a/custom_components/openai_whisper_cloud/const.py
+++ b/custom_components/openai_whisper_cloud/const.py
@@ -9,6 +9,7 @@ _LOGGER = logging.getLogger(__name__)
 CONF_PROMPT = "prompt"
 CONF_TEMPERATURE = "temperature"
 CONF_CUSTOM_PROVIDER = "custom_provider"
+CONF_REDUCE_NOISE = "reduce_noise"
 
 SUPPORTED_LANGUAGES = [
     "af",
@@ -72,3 +73,4 @@ SUPPORTED_LANGUAGES = [
 
 DEFAULT_PROMPT = ""
 DEFAULT_TEMPERATURE = 0
+DEFAULT_REDUCE_NOISE = False

--- a/custom_components/openai_whisper_cloud/manifest.json
+++ b/custom_components/openai_whisper_cloud/manifest.json
@@ -11,7 +11,7 @@
   "issue_tracker": "https://github.com/fabio-garavini/ha-openai-whisper-stt-api/issues",
   "homekit": {},
   "iot_class": "cloud_push",
-  "requirements": [],
+  "requirements": ["noisereduce", "numpy"],
   "ssdp": [],
   "zeroconf": []
 }

--- a/custom_components/openai_whisper_cloud/manifest.json
+++ b/custom_components/openai_whisper_cloud/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "openai_whisper_cloud",
   "name": "Whisper Cloud",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "codeowners": [
     "@fabio-garavini"
   ],

--- a/custom_components/openai_whisper_cloud/translations/en.json
+++ b/custom_components/openai_whisper_cloud/translations/en.json
@@ -23,11 +23,13 @@
                     "api_key": "API key",
                     "model": "Model",
                     "temperature": "Temperature",
-                    "prompt": "Prompt (Optional)"
+                    "prompt": "Prompt (Optional)",
+                    "reduce_noise": "Reduce noise"
                 },
                 "data_description": {
                     "url": "Full whisper api url. Example: `https://api.openai.com/v1/audio/transcriptions`",
-                    "prompt": "Prompt can be used to improve speech recognition of words or even names.\nou have to provide a list of words or names separated by a comma \", \".\nExample: `open, close, Chat GPT-3, DALL·E`"
+                    "prompt": "Prompt can be used to improve speech recognition of words or even names.\nYou have to provide a list of words or names separated by a comma \", \".\nExample: `open, close, Chat GPT-3, DALL·E`",
+                    "reduce_noise": "Noise reduction will remove background noise.\nAudio processing will take a bit longer."
                 }
             },
             "reconfigure": {
@@ -37,11 +39,13 @@
                     "api_key": "API key (Optional)",
                     "model": "Model",
                     "temperature": "Temperature",
-                    "prompt": "Prompt (Optional)"
+                    "prompt": "Prompt (Optional)",
+                    "reduce_noise": "Reduce noise"
                 },
                 "data_description": {
                     "url": "Full whisper api url. Example: `https://api.openai.com/v1/audio/transcriptions`",
-                    "prompt": "Prompt can be used to improve speech recognition of words or even names.\nou have to provide a list of words or names separated by a comma \", \".\nExample: `open, close, Chat GPT-3, DALL·E`"
+                    "prompt": "Prompt can be used to improve speech recognition of words or even names.\nYou have to provide a list of words or names separated by a comma \", \".\nExample: `open, close, Chat GPT-3, DALL·E`",
+                    "reduce_noise": "Noise reduction will remove background noise.\nAudio processing will take a bit longer."
                 }
             }
         }
@@ -64,10 +68,12 @@
                     "api_key": "API key (leave blank to keep existing)",
                     "model": "Model",
                     "temperature": "Temperature",
-                    "prompt": "Prompt (Optional)"
+                    "prompt": "Prompt (Optional)",
+                    "reduce_noise": "Reduce noise"
                 },
                 "data_description": {
-                    "prompt": "Prompt can be used to improve speech recognition of words or even names.\nYou have to provide a list of words or names separated by a comma \", \".\nExample: `open, close, Chat GPT-3, DALL·E`"
+                    "prompt": "Prompt can be used to improve speech recognition of words or even names.\nYou have to provide a list of words or names separated by a comma \", \".\nExample: `open, close, Chat GPT-3, DALL·E`",
+                    "reduce_noise": "Noise reduction will remove background noise.\nAudio processing will take a bit longer."
                 }
             }
         }

--- a/custom_components/openai_whisper_cloud/translations/it.json
+++ b/custom_components/openai_whisper_cloud/translations/it.json
@@ -23,11 +23,13 @@
             "api_key": "Chiave API",
             "model": "Modello",
             "temperature": "Temperatura",
-            "prompt": "Prompt (Opzionale)"
+            "prompt": "Prompt (Opzionale)",
+            "reduce_noise": "Ridurre il rumore"
           },
           "data_description": {
             "url": "Indirizzo Url completo. Esempio: `https://api.openai.com/v1/audio/transcriptions`",
-            "prompt": "Prompt puo' essere utilizzato per migliorare il riconoscimento di alcune parole o di nomi.\nFornisci una lista di parole o nomi separate da una virgola \", \".\nEsempio: `accendi, spegni, Chat GPT-3, DALL·E`"
+            "prompt": "Prompt puo' essere utilizzato per migliorare il riconoscimento di alcune parole o di nomi.\nFornisci una lista di parole o nomi separate da una virgola \", \".\nEsempio: `accendi, spegni, Chat GPT-3, DALL·E`",
+            "reduce_noise": "La riduzione del rumore rimuoverà il rumore di fondo.\nL'elaborazione dell'audio richiederà un po' più tempo."
           }
         },
         "reconfigure": {
@@ -37,11 +39,13 @@
             "api_key": "Chiave API (Optional)",
             "model": "Modello",
             "temperature": "Temperatura",
-            "prompt": "Prompt (Opzionale)"
+            "prompt": "Prompt (Opzionale)",
+            "reduce_noise": "Ridurre il rumore"
           },
           "data_description": {
             "url": "Indirizzo Url completo. Esempio: `https://api.openai.com/v1/audio/transcriptions`",
-            "prompt": "Prompt puo' essere utilizzato per migliorare il riconoscimento di alcune parole o di nomi.\nFornisci una lista di parole o nomi separate da una virgola \", \".\nEsempio: `accendi, spegni, Chat GPT-3, DALL·E`"
+            "prompt": "Prompt puo' essere utilizzato per migliorare il riconoscimento di alcune parole o di nomi.\nFornisci una lista di parole o nomi separate da una virgola \", \".\nEsempio: `accendi, spegni, Chat GPT-3, DALL·E`",
+            "reduce_noise": "La riduzione del rumore rimuoverà il rumore di fondo.\nL'elaborazione dell'audio richiederà un po' più tempo."
           }
         }
       }
@@ -64,10 +68,12 @@
             "api_key": "Chiave API",
             "model": "Modello",
             "temperature": "Temperatura",
-            "prompt": "Prompt (Opzionale)"
+            "prompt": "Prompt (Opzionale)",
+            "reduce_noise": "Ridurre il rumore"
           },
           "data_description": {
-            "prompt": "Prompt puo' essere utilizzato per migliorare il riconoscimento di alcune parole o di nomi.\nFornisci una lista di parole o nomi separate da una virgola \", \".\nEsempio: `accendi, spegni, Chat GPT-3, DALL·E`"
+            "prompt": "Prompt puo' essere utilizzato per migliorare il riconoscimento di alcune parole o di nomi.\nFornisci una lista di parole o nomi separate da una virgola \", \".\nEsempio: `accendi, spegni, Chat GPT-3, DALL·E`",
+            "reduce_noise": "La riduzione del rumore rimuoverà il rumore di fondo.\nL'elaborazione dell'audio richiederà un po' più tempo."
           }
         }
       }

--- a/custom_components/openai_whisper_cloud/translations/lv.json
+++ b/custom_components/openai_whisper_cloud/translations/lv.json
@@ -1,0 +1,81 @@
+{
+    "config": {
+        "abort": {
+            "already_configured": "Ierīce jau ir konfigurēta",
+            "reconfigure_successful": "Pārkonfigurācija veiksmīga",
+            "reconfigure_failed": "Pārkonfigurācija neizdevās"
+        },
+        "error": {
+            "invalid_api_key": "Nederīga API atslēga",
+            "unauthorized": "Lūdzu pārliecinieties, ka jūsu api atslegai ir LASŠANAS atļauja 'Modeļiem' un RAKSTĪŠANAS atauja 'Modeļu iespējām'",
+            "whisper_not_found":  "Whisper modelis nav atrasts"
+        },
+        "step": {
+            "user": {
+                "data": {
+                    "source": "API piegādātājs"
+                }
+            },
+            "whisper": {
+                "data": {
+                    "name": "Nosaukums",
+                    "url": "Url",
+                    "api_key": "API atslēga",
+                    "model": "Modelis",
+                    "temperature": "Temperatūra",
+                    "prompt": "Uzvedne (neobligāts)",
+                    "reduce_noise": "Samazināt troksni"
+                },
+                "data_description": {
+                    "url": "Pilna api adrese. Piemēram: `https://api.openai.com/v1/audio/transcriptions`",
+                    "prompt": "Uzvednes var uzlabot runas atpazīšanu netipiskiem vārdiem.\nVarat norādīt ar komatu \", \" atdalītu vārdu sarakstu.\nPiemēram: `open, close, Chat GPT-3, DALL·E`",
+                    "reduce_noise": "Trokšņu samazināšana noņems fona trokšņus.\nAudio apstrāde aizņems nedaudz ilgāk."
+                }
+            },
+            "reconfigure": {
+                "data": {
+                    "name": "Nosaukums",
+                    "url": "Url",
+                    "api_key": "API atslēga",
+                    "model": "Modelis",
+                    "temperature": "Temperatūra",
+                    "prompt": "Uzvedne (neobligāts)",
+                    "reduce_noise": "Samazināt troksni"
+                },
+                "data_description": {
+                    "url": "Pilna api adrese. Piemēram: `https://api.openai.com/v1/audio/transcriptions`",
+                    "prompt": "Uzvednes var uzlabot runas atpazīšanu netipiskiem vārdiem.\nVarat norādīt ar komatu \", \" atdalītu vārdu sarakstu.\nPiemēram: `open, close, Chat GPT-3, DALL·E`",
+                    "reduce_noise": "Trokšņu samazināšana noņems fona trokšņus.\nAudio apstrāde aizņems nedaudz ilgāk."
+                }
+            }
+        }
+    },
+    "options": {
+        "abort": {
+            "already_configured": "Device is already configured",
+            "reconfigure_successful": "Reconfigured",
+            "reconfigure_failed": "Reconfiguration failed"
+        },
+        "error": {
+            "invalid_api_key": "Invalid API Key",
+            "unauthorized": "Make sure your api key has READ permission to 'Models' and WRITE permission to 'Model capabilities'",
+            "whisper_not_found":  "Whisper model not found"
+        },
+        "step": {
+            "init": {
+                "data": {
+                    "name": "Nosaukums",
+                    "api_key": "API atslēga",
+                    "model": "Modelis",
+                    "temperature": "Temperatūra",
+                    "prompt": "Uzvedne (neobligāts)",
+                    "reduce_noise": "Samazināt troksni"
+                },
+                "data_description": {
+                    "prompt": "Uzvednes var uzlabot runas atpazīšanu netipiskiem vārdiem.\nVarat norādīt ar komatu \", \" atdalītu vārdu sarakstu.\nPiemēram: `open, close, Chat GPT-3, DALL·E`",
+                    "reduce_noise": "Trokšņu samazināšana noņems fona trokšņus.\nAudio apstrāde aizņems nedaudz ilgāk."
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adding option to run `noisereduce` before data is sent to the AI. My tests with Home Assistant Voice Preview Edition device result in quite noticeable background noise. This option cleans it out perfectly. Test on Home assistant running on Synology NAS shows delay of 0.1-0.2 or maybe 0.3 seconds with noise reduction enabled.  

Italian translations are Google translated and may need adjustment.

