### PR TITLE
Groq distil-whisper-large-v3-en deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ Currently all GroqCloud Whisper models are free up to 28800 audio seconds per da
 
 - `whisper-large-v3`
 - `whisper-large-v3-turbo` - faster version of *whisper-large-v3*
-- `distil-whisper-large-v3-en` - optimzed version of *whisper-large-v3* **only for english** language
 
 ## Mistral AI
 

--- a/custom_components/openai_whisper_cloud/__init__.py
+++ b/custom_components/openai_whisper_cloud/__init__.py
@@ -77,6 +77,23 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry):
         hass.config_entries.async_update_entry(
             config_entry, data=new_data, options=new_options, minor_version=1, version=1
         )
+    
+    if config_entry.version == 1 and config_entry.minor_version == 2 and config_entry.data.get(CONF_SOURCE) is 1 and config_entry.options.get(CONF_MODEL) is 2:
+        new_data = {
+            CONF_SOURCE: 1,
+            CONF_NAME: config_entry.data[CONF_NAME],
+            CONF_API_KEY: config_entry.data[CONF_API_KEY],
+        }
+
+        new_options = {
+            CONF_MODEL: 0,
+            CONF_TEMPERATURE: config_entry.options[CONF_TEMPERATURE],
+            CONF_PROMPT: config_entry.options[CONF_PROMPT],
+        }
+
+        hass.config_entries.async_update_entry(
+            config_entry, data=new_data, options=new_options, minor_version=1, version=3
+        )
 
     _LOGGER.info(f"Migration of {config_entry.entry_id} successful")
 

--- a/custom_components/openai_whisper_cloud/manifest.json
+++ b/custom_components/openai_whisper_cloud/manifest.json
@@ -12,6 +12,6 @@
   "issue_tracker": "https://github.com/fabio-garavini/ha-openai-whisper-stt-api/issues",
   "requirements": [],
   "ssdp": [],
-  "version": "1.2.2",
+  "version": "1.3.0",
   "zeroconf": []
 }

--- a/custom_components/openai_whisper_cloud/whisper_provider.py
+++ b/custom_components/openai_whisper_cloud/whisper_provider.py
@@ -39,8 +39,7 @@ whisper_providers = [
         "https://api.groq.com/openai",
         [
             WhisperModel("whisper-large-v3", SUPPORTED_LANGUAGES),
-            WhisperModel("whisper-large-v3-turbo", SUPPORTED_LANGUAGES),
-            WhisperModel("distil-whisper-large-v3-en", [ "en" ])
+            WhisperModel("whisper-large-v3-turbo", SUPPORTED_LANGUAGES)
         ],
         1
     ),


### PR DESCRIPTION
> GroqCloud Deprecation Notice: Switch Your Model Before 8/23
> 
> DEPRECATIONS NOTICE
> This is a notice that distil-whisper-large-v3-en will be deprecated from GroqCloud.   
> 
> We noticed you recently used distil-whisper-large-v3-en, so please be aware that if you continue setting it as your model parameter, requests will start failing August 23, 2025.
> 
> 
> ACTION
> We encourage users to migrate to and test the recommended replacement model,  whisper-large-v3-turbo.
> If you have any questions about model migration, reach out to us at support@groq.com by replying to this email.
> 
> Thanks for building fast with us,
> The Groq Team