### PR TITLE
Add Cohere as provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Whisper STT Cloud API integration for Home Assistant 🏠🎙️
+# Custom STT Cloud API integration for Home Assistant 🏠🎙️
 
 This HA custom integration lets you use any compatible OpenAI API (OpenAI, GroqCloud, Mistral AI, others coming ...) for computing speech-to-text in cloud, reducing workload on Home Assistant server.
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This HA custom integration lets you use any compatible OpenAI API (OpenAI, GroqC
 - *OpenAI*
 - *GroqCloud*
 - *Mistral AI*
+- *Cohere*
 - *Custom*
 
 ## OpenAI
@@ -47,6 +48,17 @@ Currently all GroqCloud Whisper models are free up to 28800 audio seconds per da
 Currently all Mistral AI models are free up to 1 billion token per month !
 
 - `voxtral-mini`
+
+## OpenAI
+
+### Requirements 📖
+
+- An Cohere account 👤  --> You can create one [here](https://dashboard.cohere.com/welcome/register)
+- An `API Key` 🔑 --> You can generate one [here](https://dashboard.cohere.com/api-keys)
+
+### Models
+
+- `cohere-transcribe-03-2026`
 
 ## Custom
 

--- a/custom_components/openai_whisper_cloud/stt.py
+++ b/custom_components/openai_whisper_cloud/stt.py
@@ -70,6 +70,8 @@ async def async_setup_entry(
             model= WhisperModel(config_entry.options[CONF_MODEL], SUPPORTED_LANGUAGES) if config_entry.data.get(CONF_CUSTOM_PROVIDER) else whisper_providers[config_entry.data[CONF_SOURCE]].models[config_entry.options[CONF_MODEL]],
             temperature=config_entry.options[CONF_TEMPERATURE],
             prompt=config_entry.options[CONF_PROMPT],
+            provider_name="Custom" if config_entry.data.get(CONF_CUSTOM_PROVIDER) else whisper_providers[config_entry.data[CONF_SOURCE]].name,
+            endpoint_path=None if config_entry.data.get(CONF_CUSTOM_PROVIDER) else whisper_providers[config_entry.data[CONF_SOURCE]].endpoint,
             name=config_entry.data[CONF_NAME],
             unique_id=config_entry.entry_id
         )
@@ -80,7 +82,7 @@ async def async_setup_entry(
 class OpenAIWhisperCloudEntity(SpeechToTextEntity):
     """OpenAI Whisper API provider entity."""
 
-    def __init__(self, custom: bool, api_url: str, api_key: str, model: WhisperModel, temperature, prompt, name, unique_id) -> None:
+    def __init__(self, custom: bool, api_url: str, api_key: str, model: WhisperModel, temperature, prompt, name, unique_id, provider_name="Custom", endpoint_path=None) -> None:
         """Init STT service."""
         self.custom = custom
         self.api_url = api_url
@@ -88,6 +90,8 @@ class OpenAIWhisperCloudEntity(SpeechToTextEntity):
         self.model = model
         self.temperature = temperature
         self.prompt = prompt
+        self.provider_name = provider_name
+        self.endpoint_path = endpoint_path
         self._attr_name = name
         self._attr_unique_id = unique_id
 
@@ -183,14 +187,17 @@ class OpenAIWhisperCloudEntity(SpeechToTextEntity):
                 "model": self.model.name,
                 "language": whisper_language,
                 "temperature": self.temperature,
-                "prompt": self.prompt,
-                "response_format": "json",
             }
 
-            # Make the request in a separate thread
+            if self.provider_name != "Cohere":
+                data["prompt"] = self.prompt
+                data["response_format"] = "json"
+
+            request_url = self.api_url if self.custom else f"{self.api_url}{self.endpoint_path}"
+
             response = await asyncio.to_thread(
                 requests.post,
-                f"{self.api_url}/v1/audio/transcriptions" if not self.custom else self.api_url,
+                request_url,
                 headers={
                     "Authorization": f"Bearer {self.api_key}",
                 },

--- a/custom_components/openai_whisper_cloud/stt.py
+++ b/custom_components/openai_whisper_cloud/stt.py
@@ -183,15 +183,19 @@ class OpenAIWhisperCloudEntity(SpeechToTextEntity):
                     metadata.language,
                     whisper_language,
                 )
-            data = {
-                "model": self.model.name,
-                "language": whisper_language,
-                "temperature": self.temperature,
-            }
-
-            if self.provider_name != "Cohere":
-                data["prompt"] = self.prompt
-                data["response_format"] = "json"
+            if self.provider_name == "Cohere":
+                data = {
+                    "model": self.model.name,
+                    "language": whisper_language,
+                }
+            else:
+                data = {
+                    "model": self.model.name,
+                    "language": whisper_language,
+                    "temperature": self.temperature,
+                    "prompt": self.prompt,
+                    "response_format": "json",
+                }
 
             request_url = self.api_url if self.custom else f"{self.api_url}{self.endpoint_path}"
 

--- a/custom_components/openai_whisper_cloud/whisper_provider.py
+++ b/custom_components/openai_whisper_cloud/whisper_provider.py
@@ -15,12 +15,13 @@ class WhisperModel:
 class WhisperProvider:
     """Whisper API Provider."""
 
-    def __init__(self, name: str, url: str, models: list, default_model: int) -> None:
+    def __init__(self, name: str, url: str, models: list, default_model: int, endpoint: str = "/v1/audio/transcriptions") -> None:
         """Init."""
         self.name = name
         self.url = url
         self.models = models
         self.default_model = default_model
+        self.endpoint = endpoint
 
 
 whisper_providers = [
@@ -50,6 +51,15 @@ whisper_providers = [
             WhisperModel("voxtral-mini-latest", languages = ["en", "fr", "de", "es", "it", "pt", "nl", "hi", "ar"])
         ],
         0
+    ),
+    WhisperProvider(
+        "Cohere",
+        "https://api.cohere.com",
+        [
+            WhisperModel("command-a-03-2025", SUPPORTED_LANGUAGES),
+        ],
+        0,
+        "/v2/audio/transcriptions",
     ),
     WhisperProvider("Custom", "", [], 0),
 ]

--- a/custom_components/openai_whisper_cloud/whisper_provider.py
+++ b/custom_components/openai_whisper_cloud/whisper_provider.py
@@ -56,7 +56,7 @@ whisper_providers = [
         "Cohere",
         "https://api.cohere.com",
         [
-            WhisperModel("command-a-03-2025", SUPPORTED_LANGUAGES),
+            WhisperModel("cohere-transcribe-03-2026", SUPPORTED_LANGUAGES),
         ],
         0,
         "/v2/audio/transcriptions",

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
-    "name": "OpenAI Whisper Cloud",
+    "name": "Custom STT",
     "render_readme": true,
     "homeassistant": "2023.5.0"
   }


### PR DESCRIPTION
Since cohere also offers a transcription AI service it would be nice to have this one also. 
Sadly it is not possible to use it with the custom endpoint option since cohere doesn't support the prompt and response_format fields for transcription API requests.

Best regards